### PR TITLE
convert test command to node script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 sudo: false
 language: generic
 script: .travis/deploy.sh
+branches:
+  only:
+    - master

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Only deploy on master
-[ "$TRAVIS_BRANCH" = "master" ] || exit
-
 echo 'Installing AWS CLI'
 cd
 wget https://s3.amazonaws.com/aws-cli/awscli-bundle.zip

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Place any sensitive variables in `.env` to omit them from source control.
 Several utilities are provided to easily test these scrapers while developing, since it would be a pain to have
 to run the server each time and request an endpoint in the browser over and over.
 ```bash
-> npm run test tests/test-name.js
+> npm run test -- <test name>
 ```
 Loads the environment variables from `.env` and runs the provided test using `--ignore-ssl-errors=true`
 ```bash
@@ -27,6 +27,6 @@ at the top, as seen in [water-commercial.js](tests/water-commercial.js)
 > npm run server
 ```
 Runs a web server with `GET` paths created for each test, using the name of the file without the file extension.
-For instance, `http://<domain>.com/water-commercial`. 
+For instance, `http://<domain>.com/water-commercial`.
 The request will respond with a status code of `200` if the test passes and `500` if it fails, along with
 the output of the CasperJS test.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "server": "node server.js",
-    "test": "set -a; . ./.env; set +a; CAPTURE=true $CASPERJS_BIN test --ignore-ssl-errors=true",
+    "test": "node test.js",
     "capture": "node ./node_modules/vDe/server.js"
   },
   "author": "timwis <tim@timwis.com>",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,26 @@
+var childProcess = require('child_process');
+require('dotenv').config();
+
+// load and set environment variables
+var CASPERJS_BIN = process.env.CASPERJS_BIN;
+process.env.CAPTURE = 'true';
+
+// get test name
+var testName = process.argv[2];
+if (!testName) {
+  throw new Error('Must specify script name');
+}
+
+// util for converting buffer objects to utf-8 and writing to console
+function writeBuffer(data) {
+  console.log(data.toString('utf8'));
+}
+
+var child = childProcess.spawn(
+  CASPERJS_BIN,
+  ['test', 'tests/' + testName + '.js', '--ignore-ssl-errors=true'],
+  { env: process.env }
+);
+
+child.stdout.on('data', writeBuffer);
+child.stderr.on('data', writeBuffer);


### PR DESCRIPTION
I was unable to run the test command on windows because it uses bash syntax.  This pr converts that command to a node script that runs on all platforms.